### PR TITLE
fix: `lint-staged` better config

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,0 @@
-{
-  "*.js": "npm run eslint:fix",
-  "package.json": "npx sort-package-json"
-}

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,0 +1,4 @@
+export default {
+    '**/*.?(m)js': filenames => `eslint ${filenames.join(' ')} --fix`,
+    'package.json': 'npx sort-package-json',
+};

--- a/.simple-git-hooks.json
+++ b/.simple-git-hooks.json
@@ -1,3 +1,3 @@
 {
-  "pre-commit": "npx lint-staged"
+  "pre-commit": "npx lint-staged --config ./.lintstagedrc.mjs"
 }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = {
         './rules/variables',
     ],
     ignorePatterns: [
-        '!.stylelintrc.js',
+        '!.*.js',
+        '!.*.mjs',
         '/.nuxt/**',
         '/dist/**',
         '/static/sw.*',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "vue.js"
   ],
   "scripts": {
-    "eslint": "eslint '**/*.js'",
+    "eslint": "eslint '{,.}**/{,.}*.{js,mjs}'",
     "eslint:fix": "npm run eslint -- --fix",
     "test": "tape tests/*.js",
     "update:interactive": "npx npm-check -uE"


### PR DESCRIPTION
Fixes  #48

- callback functie toegevoegd om alleen staged files te linten
- regex aanpassingen voor `ignorePatterns` en `eslint` script voor betere matching van dot files en folders