### PR TITLE
feat: remove `jsdoc` plugin + config

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,11 +8,9 @@ module.exports = {
     },
     extends: [
         'eslint:recommended',
-        'plugin:jsdoc/recommended',
         'plugin:unicorn/recommended',
         './rules/errors',
         './rules/es6',
-        './rules/jsdoc',
         './rules/practices',
         './rules/style',
         './rules/variables',
@@ -36,7 +34,6 @@ module.exports = {
         sourceType: 'module',
     },
     plugins: [
-        'jsdoc',
         'sort-destructure-keys',
         'unicorn',
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^8.0.0",
-        "eslint-plugin-jsdoc": "^39.0.0",
         "eslint-plugin-sort-destructure-keys": "^1.0.0",
         "eslint-plugin-unicorn": "^42.0.0",
         "eslint-plugin-vue": "^8.0.0",
@@ -819,20 +818,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.29.0.tgz",
-      "integrity": "sha512-4yKy5t+/joLihG+ei6CCU6sc08sjUdEdXCQ2U+9h9VP13EiqHQ4YMgDC18ys/AsLdJDBX3KRx/AWY6PR7hn52Q==",
-      "peer": true,
-      "dependencies": {
-        "comment-parser": "1.3.1",
-        "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~3.0.1"
-      },
-      "engines": {
-        "node": "^14 || ^16 || ^17 || ^18"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1706,15 +1691,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/comment-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -2184,54 +2160,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc": {
-      "version": "39.2.9",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.9.tgz",
-      "integrity": "sha512-gaPYJT94rWlWyQcisQyyEJHtLaaJqN4baFlLCEr/LcXVibS9wzQTL2dskqk327ggwqQopR+Xecu2Lng1IJ9Ypw==",
-      "peer": true,
-      "dependencies": {
-        "@es-joy/jsdoccomment": "~0.29.0",
-        "comment-parser": "1.3.1",
-        "debug": "^4.3.4",
-        "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.4.0",
-        "semver": "^7.3.7",
-        "spdx-expression-parse": "^3.0.1"
-      },
-      "engines": {
-        "node": "^14 || ^16 || ^17 || ^18"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-sort-destructure-keys": {
@@ -3536,15 +3464,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsdoc-type-pratt-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.0.1.tgz",
-      "integrity": "sha512-vqMCdAFVIiFhVgBYE/X8naf3L/7qiJsaYWTfUJZZZ124dR3OUz9HrmaMUGpYIYAN4VSuodf6gIZY0e8ktPw9cg==",
-      "peer": true,
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -6361,17 +6280,6 @@
         "@cspotcode/source-map-consumer": "0.8.0"
       }
     },
-    "@es-joy/jsdoccomment": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.29.0.tgz",
-      "integrity": "sha512-4yKy5t+/joLihG+ei6CCU6sc08sjUdEdXCQ2U+9h9VP13EiqHQ4YMgDC18ys/AsLdJDBX3KRx/AWY6PR7hn52Q==",
-      "peer": true,
-      "requires": {
-        "comment-parser": "1.3.1",
-        "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~3.0.1"
-      }
-    },
     "@eslint/eslintrc": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
@@ -6982,12 +6890,6 @@
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true
     },
-    "comment-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-      "peer": true
-    },
     "compare-func": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -7445,38 +7347,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "peer": true
-        }
-      }
-    },
-    "eslint-plugin-jsdoc": {
-      "version": "39.2.9",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.2.9.tgz",
-      "integrity": "sha512-gaPYJT94rWlWyQcisQyyEJHtLaaJqN4baFlLCEr/LcXVibS9wzQTL2dskqk327ggwqQopR+Xecu2Lng1IJ9Ypw==",
-      "peer": true,
-      "requires": {
-        "@es-joy/jsdoccomment": "~0.29.0",
-        "comment-parser": "1.3.1",
-        "debug": "^4.3.4",
-        "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.4.0",
-        "semver": "^7.3.7",
-        "spdx-expression-parse": "^3.0.1"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "peer": true
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "peer": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -8315,12 +8185,6 @@
       "requires": {
         "argparse": "^2.0.1"
       }
-    },
-    "jsdoc-type-pratt-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.0.1.tgz",
-      "integrity": "sha512-vqMCdAFVIiFhVgBYE/X8naf3L/7qiJsaYWTfUJZZZ124dR3OUz9HrmaMUGpYIYAN4VSuodf6gIZY0e8ktPw9cg==",
-      "peer": true
     },
     "jsesc": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.0",
-    "eslint-plugin-jsdoc": "^39.0.0",
     "eslint-plugin-sort-destructure-keys": "^1.0.0",
     "eslint-plugin-unicorn": "^42.0.0",
     "eslint-plugin-vue": "^8.0.0",

--- a/rules/jsdoc.js
+++ b/rules/jsdoc.js
@@ -1,9 +1,0 @@
-/* eslint-disable unicorn/prefer-module */
-
-module.exports = {
-    rules: {
-        'jsdoc/check-indentation': 'warn',
-        'jsdoc/check-syntax': 'warn',
-        'jsdoc/match-description': 'warn',
-    },
-};


### PR DESCRIPTION
Fixes #50.

Omdat de meeste projecten TS gebruiken, is `jsdoc` niet meer nodig.