### PR TITLE
fix: better formatting for arrays & import objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ module.exports = {
         sourceType: 'module',
     },
     plugins: [
+        'import-newlines',
         'sort-destructure-keys',
         'unicorn',
     ],
@@ -59,8 +60,14 @@ module.exports = {
                     '.tsx',
                 ],
                 map: [
-                    ['@', '.'],
-                    ['~', '.'],
+                    [
+                        '@',
+                        '.',
+                    ],
+                    [
+                        '~',
+                        '.',
+                    ],
                 ],
             },
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint-import-resolver-alias": "^1.0.0",
         "eslint-import-resolver-typescript": "^2.0.0",
         "eslint-plugin-import": "^2.0.0",
+        "eslint-plugin-import-newlines": "^1.0.0",
         "eslint-plugin-jsonc": "^2.0.0",
         "eslint-plugin-sort-destructure-keys": "^1.0.0",
         "eslint-plugin-unicorn": "^42.0.0",
@@ -2382,6 +2383,21 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
       }
     },
+    "node_modules/eslint-plugin-import-newlines": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-newlines/-/eslint-plugin-import-newlines-1.2.2.tgz",
+      "integrity": "sha512-SoKiFtSW/+dHsla/qzijU/RP+i8CNhYHuzfGelFf4SLpz+bzcshur6Qy7uzMow4sBg5HquAYOf/yGTKZMrbVcg==",
+      "peer": true,
+      "bin": {
+        "import-linter": "lib/index.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3305,7 +3321,7 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "peer": true,
       "engines": {
         "node": ">=0.8.19"
@@ -3322,7 +3338,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -7884,6 +7900,13 @@
         }
       }
     },
+    "eslint-plugin-import-newlines": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-newlines/-/eslint-plugin-import-newlines-1.2.2.tgz",
+      "integrity": "sha512-SoKiFtSW/+dHsla/qzijU/RP+i8CNhYHuzfGelFf4SLpz+bzcshur6Qy7uzMow4sBg5HquAYOf/yGTKZMrbVcg==",
+      "peer": true,
+      "requires": {}
+    },
     "eslint-plugin-jsonc": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.3.0.tgz",
@@ -8432,7 +8455,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "peer": true
     },
     "indent-string": {
@@ -8443,7 +8466,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-import-resolver-alias": "^1.0.0",
     "eslint-import-resolver-typescript": "^2.0.0",
     "eslint-plugin-import": "^2.0.0",
+    "eslint-plugin-import-newlines": "^1.0.0",
     "eslint-plugin-jsonc": "^2.0.0",
     "eslint-plugin-sort-destructure-keys": "^1.0.0",
     "eslint-plugin-unicorn": "^42.0.0",

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -2,10 +2,19 @@
 
 module.exports = {
     rules: {
-        'arrow-body-style': ['error', 'as-needed'],
-        'arrow-parens': ['error', 'as-needed'],
+        'arrow-body-style': [
+            'error',
+            'as-needed',
+        ],
+        'arrow-parens': [
+            'error',
+            'as-needed',
+        ],
         'arrow-spacing': 'error',
-        'generator-star-spacing': ['error', 'after'],
+        'generator-star-spacing': [
+            'error',
+            'after',
+        ],
         'no-confusing-arrow': 'error',
         'no-duplicate-imports': [
             'error',
@@ -40,6 +49,9 @@ module.exports = {
         'rest-spread-spacing': 'error',
         'symbol-description': 'error',
         'template-curly-spacing': 'error',
-        'yield-star-spacing': ['error', 'after'],
+        'yield-star-spacing': [
+            'error',
+            'after',
+        ],
     },
 };

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -18,9 +18,7 @@ module.exports = {
         'no-confusing-arrow': 'error',
         'no-duplicate-imports': [
             'error',
-            {
-                includeExports: true,
-            },
+            { includeExports: true },
         ],
         'no-useless-computed-key': 'error',
         'no-useless-rename': 'error',

--- a/rules/json.js
+++ b/rules/json.js
@@ -18,7 +18,10 @@ module.exports = {
             },
         ],
         'jsonc/comma-style': 'error',
-        'jsonc/indent': ['error', 2],
+        'jsonc/indent': [
+            'error',
+            2,
+        ],
         'jsonc/key-spacing': [
             'error',
             {
@@ -28,13 +31,19 @@ module.exports = {
             },
         ],
         'jsonc/no-octal-escape': 'error',
-        'jsonc/object-curly-newline': ['error', {
-            ObjectExpression: {
-                minProperties: 2,
-                multiline: true,
+        'jsonc/object-curly-newline': [
+            'error',
+            {
+                ObjectExpression: {
+                    minProperties: 2,
+                    multiline: true,
+                },
             },
-        }],
-        'jsonc/object-curly-spacing': ['error', 'always'],
+        ],
+        'jsonc/object-curly-spacing': [
+            'error',
+            'always',
+        ],
         'jsonc/object-property-newline': 'error',
         'jsonc/sort-keys': [
             'error',

--- a/rules/plugins.js
+++ b/rules/plugins.js
@@ -1,9 +1,11 @@
 /* eslint-disable unicorn/prefer-module */
 
 const importPlugin = require('./plugins/import');
+const importNewlinesPlugin = require('./plugins/import-newlines');
 
 module.exports = {
     rules: {
+        ...importNewlinesPlugin,
         ...importPlugin,
     },
 };

--- a/rules/plugins/import-newlines.js
+++ b/rules/plugins/import-newlines.js
@@ -1,0 +1,11 @@
+/* eslint-disable unicorn/prefer-module */
+
+module.exports = {
+    'import-newlines/enforce': [
+        'error',
+        {
+            'items': 3,
+            'max-len': 120,
+        },
+    ],
+};

--- a/rules/practices.js
+++ b/rules/practices.js
@@ -4,9 +4,15 @@ module.exports = {
     rules: {
         'array-callback-return': 'error',
         'block-scoped-var': 'error',
-        'complexity': ['error', 10],
+        'complexity': [
+            'error',
+            10,
+        ],
         'consistent-return': 'error',
-        'curly': ['error', 'all'],
+        'curly': [
+            'error',
+            'all',
+        ],
         'dot-notation': 'error',
         'eqeqeq': 'error',
         'guard-for-in': 'error',

--- a/rules/style.js
+++ b/rules/style.js
@@ -39,9 +39,7 @@ module.exports = {
         'indent': [
             'error',
             4,
-            {
-                SwitchCase: 1,
-            },
+            { SwitchCase: 1 },
         ],
         'key-spacing': 'error',
         'keyword-spacing': 'error',
@@ -51,9 +49,7 @@ module.exports = {
         'max-depth': 'error',
         'max-len': [
             'warn',
-            {
-                code: 120,
-            },
+            { code: 120 },
         ],
         'max-lines': 'warn',
         'max-lines-per-function': [
@@ -79,31 +75,23 @@ module.exports = {
         'no-multi-assign': 'error',
         'no-multiple-empty-lines': [
             'error',
-            {
-                max: 1,
-            },
+            { max: 1 },
         ],
         'no-negated-condition': 'error',
         'no-new-object': 'error',
         'no-plusplus': [
             'error',
-            {
-                allowForLoopAfterthoughts: true,
-            },
+            { allowForLoopAfterthoughts: true },
         ],
         'no-tabs': 'error',
         'no-trailing-spaces': 'error',
         'no-underscore-dangle': [
             'error',
-            {
-                enforceInMethodNames: true,
-            },
+            { enforceInMethodNames: true },
         ],
         'no-unneeded-ternary': [
             'error',
-            {
-                defaultAssignment: false,
-            },
+            { defaultAssignment: false },
         ],
         'no-whitespace-before-property': 'error',
         'object-curly-newline': [
@@ -113,16 +101,12 @@ module.exports = {
                     minProperties: 2,
                     multiline: true,
                 },
-                ImportDeclaration: {
-                    minProperties: 4,
-                    multiline: true,
-                },
                 ObjectExpression: {
-                    minProperties: 1,
+                    minProperties: 2,
                     multiline: true,
                 },
                 ObjectPattern: {
-                    minProperties: 4,
+                    minProperties: 2,
                     multiline: true,
                 },
             },
@@ -179,9 +163,7 @@ module.exports = {
         'sort-keys': [
             'error',
             'asc',
-            {
-                natural: true,
-            },
+            { natural: true },
         ],
         'sort-vars': 'error',
         'space-before-blocks': 'error',

--- a/rules/style.js
+++ b/rules/style.js
@@ -2,25 +2,47 @@
 
 module.exports = {
     rules: {
-        'array-bracket-newline': ['error', 'consistent'],
+        'array-bracket-newline': [
+            'error',
+            {
+                minItems: 2,
+                multiline: true,
+            },
+        ],
         'array-bracket-spacing': 'error',
-        'array-element-newline': ['error', 'consistent'],
+        'array-element-newline': [
+            'error',
+            {
+                minItems: 2,
+                multiline: true,
+            },
+        ],
         'block-spacing': 'error',
         'brace-style': 'error',
         'camelcase': 'error',
-        'comma-dangle': ['error', 'always-multiline'],
+        'comma-dangle': [
+            'error',
+            'always-multiline',
+        ],
         'comma-spacing': 'error',
         'comma-style': 'error',
         'computed-property-spacing': 'error',
         'consistent-this': 'error',
         'eol-last': 'error',
         'func-name-matching': 'error',
-        'func-names': ['error', 'never'],
+        'func-names': [
+            'error',
+            'never',
+        ],
         'func-style': 'error',
         'implicit-arrow-linebreak': 'error',
-        'indent': ['error', 4, {
-            SwitchCase: 1,
-        }],
+        'indent': [
+            'error',
+            4,
+            {
+                SwitchCase: 1,
+            },
+        ],
         'key-spacing': 'error',
         'keyword-spacing': 'error',
         'line-comment-position': 'error',
@@ -44,7 +66,10 @@ module.exports = {
         'max-params': 'error',
         'max-statements': 'warn',
         'max-statements-per-line': 'error',
-        'multiline-ternary': ['error', 'never'],
+        'multiline-ternary': [
+            'error',
+            'never',
+        ],
         'new-cap': 'error',
         'new-parens': 'error',
         'newline-per-chained-call': 'error',
@@ -81,30 +106,45 @@ module.exports = {
             },
         ],
         'no-whitespace-before-property': 'error',
-        'object-curly-newline': ['error', {
-            ExportDeclaration: {
-                minProperties: 2,
-                multiline: true,
+        'object-curly-newline': [
+            'error',
+            {
+                ExportDeclaration: {
+                    minProperties: 2,
+                    multiline: true,
+                },
+                ImportDeclaration: {
+                    minProperties: 4,
+                    multiline: true,
+                },
+                ObjectExpression: {
+                    minProperties: 1,
+                    multiline: true,
+                },
+                ObjectPattern: {
+                    minProperties: 4,
+                    multiline: true,
+                },
             },
-            ImportDeclaration: {
-                minProperties: 4,
-                multiline: true,
-            },
-            ObjectExpression: {
-                minProperties: 1,
-                multiline: true,
-            },
-            ObjectPattern: {
-                minProperties: 4,
-                multiline: true,
-            },
-        }],
-        'object-curly-spacing': ['error', 'always'],
+        ],
+        'object-curly-spacing': [
+            'error',
+            'always',
+        ],
         'object-property-newline': 'error',
-        'one-var': ['error', 'never'],
-        'one-var-declaration-per-line': ['error', 'always'],
+        'one-var': [
+            'error',
+            'never',
+        ],
+        'one-var-declaration-per-line': [
+            'error',
+            'always',
+        ],
         'operator-assignment': 'error',
-        'operator-linebreak': ['error', 'after'],
+        'operator-linebreak': [
+            'error',
+            'after',
+        ],
         'padding-line-between-statements': [
             'error',
             {
@@ -114,7 +154,10 @@ module.exports = {
             },
         ],
         'prefer-object-spread': 'error',
-        'quote-props': ['error', 'consistent-as-needed'],
+        'quote-props': [
+            'error',
+            'consistent-as-needed',
+        ],
         'quotes': [
             'error',
             'single',
@@ -127,7 +170,8 @@ module.exports = {
         'semi-style': 'error',
         'sort-destructure-keys/sort-destructure-keys': 'error',
         'sort-imports': [
-            'error', {
+            'error',
+            {
                 ignoreCase: true,
                 ignoreDeclarationSort: true,
             },

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -16,11 +16,17 @@ module.exports = {
                 registeredComponentsOnly: false,
             },
         ],
-        'vue/html-indent': ['error', 4],
+        'vue/html-indent': [
+            'error',
+            4,
+        ],
         'vue/multi-word-component-names': 'off',
         'vue/no-empty-component-block': 'error',
         'vue/no-template-target-blank': 'error',
-        'vue/padding-line-between-blocks': ['error', 'always'],
+        'vue/padding-line-between-blocks': [
+            'error',
+            'always',
+        ],
         'vue/singleline-html-element-content-newline': 'off',
         'vue/v-on-function-call': 'error',
         'vuejs-accessibility/label-has-for': [
@@ -28,7 +34,10 @@ module.exports = {
             {
                 allowChildren: true,
                 required: {
-                    some: ['nesting', 'id'],
+                    some: [
+                        'nesting',
+                        'id',
+                    ],
                 },
             },
         ],

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -12,9 +12,7 @@ module.exports = {
         'vue/component-name-in-template-casing': [
             'error',
             'PascalCase',
-            {
-                registeredComponentsOnly: false,
-            },
+            { registeredComponentsOnly: false },
         ],
         'vue/html-indent': [
             'error',

--- a/typescript.js
+++ b/typescript.js
@@ -18,9 +18,7 @@ module.exports = {
     settings: {
         'import/resolver': {
             ...base.settings['import/resolver'],
-            typescript: {
-                alwaysTryTypes: true,
-            },
+            typescript: { alwaysTryTypes: true },
         },
     },
 };

--- a/vue.js
+++ b/vue.js
@@ -14,9 +14,7 @@ module.exports = {
             ],
             files: ['**/*.vue'],
             parser: 'vue-eslint-parser',
-            parserOptions: {
-                parser: '@babel/eslint-parser',
-            },
+            parserOptions: { parser: '@babel/eslint-parser' },
         },
     ],
 };


### PR DESCRIPTION
Voor array's:
- één item -> single line
- meer dan één item -> multiline

Voor import objects:
- als de lengte minder dan 120 is én maximaal 3 items -> single line
- lengte meer dan 120 of meer dan 3 items -> multiline